### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3
+
+WORKDIR /usr/src/nano-dlna/
+COPY . /usr/src/nano-dlna/
+
+RUN pip install --no-cache .
+
+ENTRYPOINT [ "nanodlna" ]
+CMD [ "--help" ]


### PR DESCRIPTION
Add Dockerfile to enable image building. Useful for development and tests under Docker workflow.
Using the official Python 3 image, latest tag. More info at https://hub.docker.com/_/python/
 
Just adding files, setting working dir and running install and build.
 
Build:
 
```
$ docker build -t nanodlna .
```
 
Run:
 
```
$ docker run --rm -it --net=host -v $HOME/Videos/:/media/:ro nanodlna play /media/myVideo.mp4
```
 
FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:
 
```
$ docker run --rm -it --net=host -v $HOME/Videos/:/media/:ro pataquets/nano-dlna-src play /media/myVideo.mp4
```
 
Using `--rm` causes container it to be deleted after stop and `-it` makes the container not to go background and run interactively. Using `--net=host` to allow listening on local interfaces. Otherwise, you would need to map ports from Docker host to container.
To access host's local media, just mount directories inside the Docker container as above. Use as many `-v` switches as needed.
 
Optional improvement to come (maybe in another issue):
- Create an 'official', based on your repo, automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/ . Just requires a free Docker Hub account and a following a quick 'Create automated build' process. I'll be happy to help on it, if needed.