### PR TITLE
add param to set the server ip

### DIFF
--- a/nanodlna/cli.py
+++ b/nanodlna/cli.py
@@ -65,7 +65,10 @@ def play(args):
     # Configure streaming server
 
     target_ip = device["hostname"]
-    serve_ip = streaming.get_serve_ip(target_ip)
+    if args.local_host:
+        serve_ip = args.local_host
+    else:
+        serve_ip = streaming.get_serve_ip(target_ip)
     files_urls = streaming.start_server(files, serve_ip)
 
     # Play the video through DLNA protocol
@@ -85,6 +88,7 @@ def run():
 
     p_play = subparsers.add_parser('play')
     p_play.add_argument("-d", "--device", dest="device_url")
+    p_play.add_argument("-H", "--host", dest="local_host")
     p_play.add_argument("-q", "--query-device", dest="device_query")
     p_play.add_argument("-s", "--subtitle", dest="file_subtitle")
     p_play.add_argument("-n", "--no-subtitle",


### PR DESCRIPTION
In the case dlna run in a sub network like 192.168.100.50 and the router joins network 192.168.1.x as 192.168.1.5
and router set up DMZ to 192.168.1.5 -> 192.168.100.50
we should specify self as 192.168.1.5 instead of 192.168.100.50 with param -H