### PR TITLE
Develop

### DIFF
--- a/nanodlna/cli.py
+++ b/nanodlna/cli.py
@@ -133,9 +133,15 @@ def play(args):
 
 def build_handler_stop(device):
     def signal_handler(sig, frame):
-        logging.info("Interrupt signal detected, sending stop command to device")
+        logging.info(
+            "Interrupt signal detected"
+            "sending stop command to device"
+        )
         dlna.stop(device)
-        sys.exit("Interrupt signal detected, sent stop command to device, exiting now")
+        sys.exit(
+            "Interrupt signal detected"
+            "sent stop command to device, exiting now"
+        )
     return signal_handler
 
 

--- a/nanodlna/cli.py
+++ b/nanodlna/cli.py
@@ -53,7 +53,7 @@ def list_devices(args):
     set_logs(args)
 
     logging.info("Scanning devices...")
-    my_devices = devices.get_devices(args.timeout)
+    my_devices = devices.get_devices(args.timeout, args.local_host)
     logging.info("Number of devices found: {}".format(len(my_devices)))
 
     for i, device in enumerate(my_devices, 1):
@@ -70,7 +70,7 @@ def find_device(args):
         logging.info("Select device by URL")
         device = devices.register_device(args.device_url)
     else:
-        my_devices = devices.get_devices(args.timeout)
+        my_devices = devices.get_devices(args.timeout, args.local_host)
 
         if len(my_devices) > 0:
             if args.device_query:
@@ -180,6 +180,7 @@ def run():
     parser = argparse.ArgumentParser(
         description="A minimal UPnP/DLNA media streamer.")
     parser.set_defaults(func=lambda args: parser.print_help())
+    parser.add_argument("-H", "--host", dest="local_host")
     parser.add_argument("-t", "--timeout", type=float, default=5)
     parser.add_argument("-b", "--debug",
                         dest="debug_activated", action="store_true")
@@ -190,7 +191,6 @@ def run():
 
     p_play = subparsers.add_parser('play')
     p_play.add_argument("-d", "--device", dest="device_url")
-    p_play.add_argument("-H", "--host", dest="local_host")
     p_play.add_argument("-q", "--query-device", dest="device_query")
     p_play.add_argument("-s", "--subtitle", dest="file_subtitle")
     p_play.add_argument("-n", "--no-subtitle",

--- a/nanodlna/cli.py
+++ b/nanodlna/cli.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import sys
+import signal
 import datetime
 import tempfile
 
@@ -122,9 +123,20 @@ def play(args):
 
     logging.info("Streaming server ready")
 
+    # Register handler if interrupt signal is received
+    signal.signal(signal.SIGINT, build_handler_stop(device))
+
     # Play the video through DLNA protocol
     logging.info("Sending play command")
     dlna.play(files_urls, device)
+
+
+def build_handler_stop(device):
+    def signal_handler(sig, frame):
+        logging.info("Interrupt signal detected, sending stop command to device")
+        dlna.stop(device)
+        sys.exit("Interrupt signal detected, sent stop command to device, exiting now")
+    return signal_handler
 
 
 def pause(args):

--- a/nanodlna/cli.py
+++ b/nanodlna/cli.py
@@ -133,14 +133,20 @@ def play(args):
 
 def build_handler_stop(device):
     def signal_handler(sig, frame):
-        logging.info(
-            "Interrupt signal detected"
-            "sending stop command to device"
-        )
+
+        logging.info("Interrupt signal detected")
+
+        logging.info("Sending stop command to render device")
         dlna.stop(device)
+
+        logging.info("Stopping streaming server")
+        streaming.stop_server()
+
         sys.exit(
-            "Interrupt signal detected"
-            "sent stop command to device, exiting now"
+            "Interrupt signal detected. "
+            "Sent stop command to render device and "
+            "stopped streaming. "
+            "nano-dlna will exit now!"
         )
     return signal_handler
 

--- a/nanodlna/cli.py
+++ b/nanodlna/cli.py
@@ -59,27 +59,8 @@ def list_devices(args):
         print("Device {0}:\n{1}\n\n".format(i, json.dumps(device, indent=4)))
 
 
-def play(args):
+def find_device(args):
 
-    set_logs(args)
-
-    logging.info("Starting to play")
-
-    # Get video and subtitle file names
-
-    files = {"file_video": args.file_video}
-
-    if args.use_subtitle:
-
-        if not args.file_subtitle:
-            args.file_subtitle = get_subtitle(args.file_video)
-
-        if args.file_subtitle:
-            files["file_subtitle"] = args.file_subtitle
-
-    logging.info("Media files: {}".format(json.dumps(files)))
-
-    # Select device to play
     logging.info("Selecting device to play")
 
     device = None
@@ -100,6 +81,30 @@ def play(args):
                 logging.info("Select first device")
                 device = my_devices[0]
 
+    return device
+
+
+def play(args):
+
+    set_logs(args)
+
+    logging.info("Starting to play")
+
+    # Get video and subtitle file names
+
+    files = {"file_video": args.file_video}
+
+    if args.use_subtitle:
+
+        if not args.file_subtitle:
+            args.file_subtitle = get_subtitle(args.file_video)
+
+        if args.file_subtitle:
+            files["file_subtitle"] = args.file_subtitle
+
+    logging.info("Media files: {}".format(json.dumps(files)))
+
+    device = find_device(args)
     if not device:
         sys.exit("No devices found.")
 
@@ -120,6 +125,30 @@ def play(args):
     # Play the video through DLNA protocol
     logging.info("Sending play command")
     dlna.play(files_urls, device)
+
+
+def pause(args):
+
+    set_logs(args)
+
+    logging.info("Selecting device to pause")
+    device = find_device(args)
+
+    # Pause through DLNA protocol
+    logging.info("Sending pause command")
+    dlna.pause(device)
+
+
+def stop(args):
+
+    set_logs(args)
+
+    logging.info("Selecting device to stop")
+    device = find_device(args)
+
+    # Stop through DLNA protocol
+    logging.info("Sending stop command")
+    dlna.stop(device)
 
 
 def run():
@@ -144,6 +173,16 @@ def run():
                         dest="use_subtitle", action="store_false")
     p_play.add_argument("file_video")
     p_play.set_defaults(func=play)
+
+    p_pause = subparsers.add_parser('pause')
+    p_pause.add_argument("-d", "--device", dest="device_url")
+    p_pause.add_argument("-q", "--query-device", dest="device_query")
+    p_pause.set_defaults(func=pause)
+
+    p_stop = subparsers.add_parser('stop')
+    p_stop.add_argument("-d", "--device", dest="device_url")
+    p_stop.add_argument("-q", "--query-device", dest="device_query")
+    p_stop.set_defaults(func=stop)
 
     args = parser.parse_args()
 

--- a/nanodlna/devices.py
+++ b/nanodlna/devices.py
@@ -35,14 +35,20 @@ def register_device(location_url):
     xml = re.sub(" xmlns=\"[^\"]+\"", "", xml, count=1)
     info = ET.fromstring(xml)
 
+def register_device(location_url):
+
+    xml_raw = urllibreq.urlopen(location_url).read().decode("UTF-8")
     logging.debug(
         "Device to be registered: {}".format(
             json.dumps({
                 "location_url": location_url,
-                "raw": xml
+                "xml_raw": xml_raw
             })
         )
     )
+
+    xml = re.sub(r"""\s(xmlns="[^"]+"|xmlns='[^']+')""", '', xml_raw, count=1)
+    info = ET.fromstring(xml)
 
     location = urllibparse.urlparse(location_url)
     hostname = location.hostname

--- a/nanodlna/devices.py
+++ b/nanodlna/devices.py
@@ -139,9 +139,17 @@ def get_devices(timeout=3.0):
         except Exception:
             pass
 
-    devices_urls = [dev["location"]
-                    for dev in devices if "AVTransport" in dev["st"]]
-    devices = [register_device(location_url) for location_url in devices_urls]
+    devices_urls = [
+        dev["location"]
+        for dev in devices
+        if "st" in dev and
+           "AVTransport" in dev["st"]
+    ]
+
+    devices = [
+        register_device(location_url)
+        for location_url in devices_urls
+    ]
 
     return devices
 

--- a/nanodlna/devices.py
+++ b/nanodlna/devices.py
@@ -100,6 +100,17 @@ def register_device(location_url):
     return device
 
 
+def remove_duplicates(devices):
+    seen = set()
+    result_devices = []
+    for device in devices:
+        device_str = str(device)
+        if device_str not in seen:
+            result_devices.append(device)
+            seen.add(device_str)
+    return result_devices
+
+
 def get_devices(timeout=3.0):
 
     logging.debug("Configuring broadcast message")
@@ -150,6 +161,8 @@ def get_devices(timeout=3.0):
         register_device(location_url)
         for location_url in devices_urls
     ]
+
+    devices = remove_duplicates(devices)
 
     return devices
 

--- a/nanodlna/devices.py
+++ b/nanodlna/devices.py
@@ -35,6 +35,15 @@ def register_device(location_url):
     xml = re.sub(" xmlns=\"[^\"]+\"", "", xml, count=1)
     info = ET.fromstring(xml)
 
+    logging.debug(
+        "Device to be registered: {}".format(
+            json.dumps({
+                "location_url": location_url,
+                "raw": xml
+            })
+        )
+    )
+
     location = urllibparse.urlparse(location_url)
     hostname = location.hostname
 

--- a/nanodlna/dlna.py
+++ b/nanodlna/dlna.py
@@ -28,7 +28,9 @@ def send_dlna_action(device, data, action):
 
     action_data = pkgutil.get_data(
         "nanodlna", "templates/action-{0}.xml".format(action)).decode("UTF-8")
-    action_data = action_data.format(**data).encode("UTF-8")
+    if data:
+        action_data = action_data.format(**data)
+    action_data = action_data.encode("UTF-8")
 
     headers = {
         "Content-Type": "text/xml; charset=\"utf-8\"",
@@ -95,3 +97,21 @@ def play(files_urls, device):
     send_dlna_action(device, video_data, "SetAVTransportURI")
     logging.debug("Playing video")
     send_dlna_action(device, video_data, "Play")
+
+
+def pause(device):
+    logging.debug("Pausing device: {}".format(
+        json.dumps({
+            "device": device
+        })
+    ))
+    send_dlna_action(device, None, "Pause")
+
+
+def stop(device):
+    logging.debug("Stopping device: {}".format(
+        json.dumps({
+            "device": device
+        })
+    ))
+    send_dlna_action(device, None, "Stop")

--- a/nanodlna/streaming.py
+++ b/nanodlna/streaming.py
@@ -88,6 +88,10 @@ def start_server(files, serve_ip, serve_port=9000):
     return files_urls
 
 
+def stop_server():
+    reactor.stop()
+
+
 def get_serve_ip(target_ip, target_port=80):
     logging.debug("Identifying server IP")
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)

--- a/nanodlna/templates/action-Pause.xml
+++ b/nanodlna/templates/action-Pause.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='utf-8'?>
+<s:Envelope s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+  <s:Body>
+    <u:Pause xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">
+      <InstanceID>0</InstanceID>
+    </u:Pause>
+  </s:Body>
+</s:Envelope>

--- a/nanodlna/templates/action-Stop.xml
+++ b/nanodlna/templates/action-Stop.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='utf-8'?>
+<s:Envelope s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+  <s:Body>
+    <u:Stop xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">
+      <InstanceID>0</InstanceID>
+    </u:Stop>
+  </s:Body>
+</s:Envelope>

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if sys.version_info.major == 2:
 
 setup(
     name='nanodlna',
-    version='0.2.1',
+    version='0.3.0',
     description='A minimal UPnP/DLNA media streamer',
     long_description="""nano-dlna is a command line tool that allows you to
  play a local video file in your TV (or any other DLNA compatible device)""",


### PR DESCRIPTION
- Explicitly packs the TTL as unsigned char, in order to make the socket options work on OpenBSD. Thanks to @vext01 for reporting the error.
- Bind the multicast socket to `0.0.0.0` (instead of empty string), and bind it to the specified host when explicitly specified. Hopefully this will make nano-dlna find devices in hosts with multiple network adapters. Thanks to @vext01 for reporting it.
- Discover devices/services available in a single multi-device hardware (DLNA `deviceList`). Thanks to @s482dcaw for reporting the problem and also proposing a solution with a PR.
- Implemented the `pause` and `stop` CLI actions. Thanks to @s482dcaw for implementing this.
- Omit duplicated devices from the list result
- Check if the broadcast message has the `st` field before parsing and registering the device
- Handles SIGINT (including Ctrl + C), so that we send an STOP command to the render